### PR TITLE
P-11. dast zap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 APP_ENV=dev
 LOG_LEVEL=info
 # Generate a unique secret before running the API (>=32 characters)
-JWT_SECRET_KEY=replace-with-a-strong-secret
+JWT_SECRET_KEY=replace-with-a-strong-secret-0123456789012345678901234567
 
 DATABASE_URL=sqlite:////data/parking.db
 

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -1,0 +1,183 @@
+name: Security - DAST
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "app/**"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "scripts/**"
+      - ".github/workflows/ci-p11-dast.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dast_zap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      TARGET_URL: http://localhost:8000
+      HEALTH_URL: http://localhost:8000/health
+      GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure evidence dir
+        run: mkdir -p EVIDENCE/P11
+
+      - name: Prepare .env for compose (if missing)
+        run: |
+          set -euo pipefail
+          if [ -f .env.example ] && [ ! -f .env ]; then
+            cp .env.example .env
+          fi
+
+      - name: Build & start service (docker compose)
+        run: |
+          set -euo pipefail
+          docker compose up -d --build
+
+      - name: Wait for service readiness (healthcheck)
+        run: |
+          set -euo pipefail
+          echo "Waiting for ${HEALTH_URL}..."
+          for i in {1..30}; do
+            if curl -fsS "${HEALTH_URL}" > /dev/null; then
+              echo "Service is ready"
+              exit 0
+            fi
+            echo "Attempt ${i}/30: not ready yet"
+            sleep 3
+          done
+          echo "Service did not become ready in time"
+          docker compose ps
+          docker compose logs --no-color
+          exit 1
+
+      - name: Smoke test target
+        run: |
+          set -euo pipefail
+          curl -fsS "${TARGET_URL}/health"
+
+      - name: Run OWASP ZAP baseline
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --network host \
+            -v "$PWD:/zap/wrk" \
+            ghcr.io/zaproxy/zap2docker-stable \
+            zap-baseline.py \
+              -t "${TARGET_URL}" \
+              -r EVIDENCE/P11/zap_baseline.html \
+              -J EVIDENCE/P11/zap_baseline.json \
+              -m 5 \
+              -T 10 \
+            || true
+
+
+      - name: Generate ZAP summary (markdown)
+        run: |
+          python - << 'PY'
+          import json, os
+          from pathlib import Path
+
+          evidence = Path("EVIDENCE/P11")
+          report_path = evidence / "zap_baseline.json"
+          out_path = evidence / "zap_summary.md"
+
+          def count_alerts(d):
+            alerts = []
+            if isinstance(d, dict):
+              if "site" in d:
+                for s in d.get("site", []):
+                  alerts += s.get("alerts", []) or []
+              if "alerts" in d and isinstance(d["alerts"], list):
+                alerts += d["alerts"]
+            return alerts
+
+          summary = []
+          summary.append("# ZAP baseline summary\n")
+
+          total = 0
+          sev = {"High": 0, "Medium": 0, "Low": 0, "Informational": 0, "Unknown": 0}
+          top = []
+
+          if report_path.exists():
+            try:
+              data = json.loads(report_path.read_text(encoding="utf-8"))
+              alerts = count_alerts(data)
+              total = len(alerts)
+
+              for a in alerts:
+                risk = (a.get("risk") or a.get("riskdesc") or "").strip()
+                if risk:
+                  risk = risk.split()[0]
+                if risk not in sev:
+                  risk = "Unknown"
+                sev[risk] += 1
+
+              for a in alerts[:5]:
+                name = a.get("name") or a.get("alert") or "Unknown alert"
+                risk = (a.get("risk") or a.get("riskdesc") or "").strip()
+                if risk:
+                  risk = risk.split()[0]
+                if not risk:
+                  risk = "Unknown"
+                top.append((risk, name))
+
+            except Exception as e:
+              summary.append(f"Не удалось распарсить zap_baseline.json: {e}\n")
+          else:
+            summary.append("Отчёт zap_baseline.json не найден.\n")
+
+          summary.append(f"**Target:** `{os.environ.get('TARGET_URL','')}`")
+          summary.append(f"**Всего алертов:** {total}\n")
+          summary.append("## Распределение по severity\n")
+          summary.append(f"- High: {sev['High']}")
+          summary.append(f"- Medium: {sev['Medium']}")
+          summary.append(f"- Low: {sev['Low']}")
+          summary.append(f"- Informational: {sev['Informational']}")
+          summary.append(f"- Unknown: {sev['Unknown']}\n")
+
+          if top:
+            summary.append("## Примеры алертов (первые 5)\n")
+            for risk, name in top:
+              summary.append(f"- {risk}: {name}")
+            summary.append("")
+
+          sha = os.environ.get("GITHUB_SHA", "")
+          run_url = os.environ.get("GITHUB_RUN_URL", "")
+          summary.append("---")
+          if sha:
+            summary.append(f"Commit: `{sha}`")
+          if run_url:
+            summary.append(f"Workflow run: {run_url}")
+          summary.append("")
+
+          out_path.write_text("\n".join(summary), encoding="utf-8")
+          PY
+
+      - name: Upload ZAP evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: P11_EVIDENCE
+          path: EVIDENCE/P11
+
+      - name: Show compose status & logs
+        if: always()
+        run: |
+          docker compose ps || true
+          docker compose logs --no-color || true
+
+      - name: Docker Compose down
+        if: always()
+        run: docker compose down -v || true

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -94,20 +94,28 @@ jobs:
           set -euo pipefail
           curl -fsS "${TARGET_URL}/health"
 
+      - name: Ensure evidence dir perms
+        run: |
+          mkdir -p EVIDENCE/P11
+          chmod -R a+rwx EVIDENCE/P11
+
       - name: Run OWASP ZAP baseline
         run: |
           set -euo pipefail
           docker run --rm \
             --network host \
+            -u "$(id -u):$(id -g)" \
             -v "$PWD:/zap/wrk" \
+            -w /zap/wrk \
             ghcr.io/zaproxy/zap2docker-stable \
             zap-baseline.py \
               -t "${TARGET_URL}" \
-              -r EVIDENCE/P11/zap_baseline.html \
-              -J EVIDENCE/P11/zap_baseline.json \
+              -r /zap/wrk/EVIDENCE/P11/zap_baseline.html \
+              -J /zap/wrk/EVIDENCE/P11/zap_baseline.json \
               -m 5 \
               -T 10 \
-            || true
+            2>&1 | tee EVIDENCE/P11/zap_baseline.log || true
+
 
       - name: Generate ZAP summary (markdown)
         run: |

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -125,6 +125,7 @@ jobs:
           set +e
           docker run --rm \
             --network host \
+            -e HOME=/zap/wrk \
             -u "$(id -u):$(id -g)" \
             -v "$PWD:/zap/wrk" \
             -w /zap/wrk \

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -1,4 +1,4 @@
-name: Security - DAST
+name: Security - DAST (OWASP ZAP Baseline)
 
 on:
   workflow_dispatch:
@@ -9,6 +9,7 @@ on:
       - "docker-compose.yml"
       - "scripts/**"
       - ".github/workflows/ci-p11-dast.yml"
+      - ".env.example"
 
 permissions:
   contents: read
@@ -24,7 +25,7 @@ jobs:
     env:
       TARGET_URL: http://localhost:8000
       HEALTH_URL: http://localhost:8000/health
-      GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      JWT_SECRET_KEY: jwt-secret-ci-demo-key-0123456789012345678901234567
 
     steps:
       - name: Checkout
@@ -33,32 +34,58 @@ jobs:
       - name: Ensure evidence dir
         run: mkdir -p EVIDENCE/P11
 
-      - name: Prepare .env for compose (if missing)
+      - name: Write CI debug metadata
+        run: |
+          {
+            echo "# P11 CI debug"
+            echo
+            echo "Commit: \`${GITHUB_SHA}\`"
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "Target: ${TARGET_URL}"
+          } > EVIDENCE/P11/ci_debug.md
+
+      - name: Prepare .env for compose (CI)
         run: |
           set -euo pipefail
-          if [ -f .env.example ] && [ ! -f .env ]; then
+
+          if [ -f .env.example ]; then
             cp .env.example .env
+          else
+            : > .env
           fi
+
+          if grep -q '^JWT_SECRET_KEY=' .env; then
+            sed -i "s/^JWT_SECRET_KEY=.*/JWT_SECRET_KEY=${JWT_SECRET_KEY}/" .env
+          else
+            echo "JWT_SECRET_KEY=${JWT_SECRET_KEY}" >> .env
+          fi
+
+          if ! grep -q '^DATABASE_URL=' .env; then
+            echo "DATABASE_URL=sqlite:////data/parking.db" >> .env
+          fi
+
+          echo "Prepared .env (keys only):"
+          grep -E '^(JWT_SECRET_KEY|DATABASE_URL)=' .env | sed 's/JWT_SECRET_KEY=.*/JWT_SECRET_KEY=***masked***/'
 
       - name: Build & start service (docker compose)
         run: |
           set -euo pipefail
           docker compose up -d --build
+          docker compose ps
 
       - name: Wait for service readiness (healthcheck)
         run: |
           set -euo pipefail
           echo "Waiting for ${HEALTH_URL}..."
-          for i in {1..30}; do
+          for i in {1..40}; do
             if curl -fsS "${HEALTH_URL}" > /dev/null; then
               echo "Service is ready"
               exit 0
             fi
-            echo "Attempt ${i}/30: not ready yet"
+            echo "Attempt ${i}/40: not ready yet"
             sleep 3
           done
           echo "Service did not become ready in time"
-          docker compose ps
           docker compose logs --no-color
           exit 1
 
@@ -82,7 +109,6 @@ jobs:
               -T 10 \
             || true
 
-
       - name: Generate ZAP summary (markdown)
         run: |
           python - << 'PY'
@@ -93,90 +119,73 @@ jobs:
           report_path = evidence / "zap_baseline.json"
           out_path = evidence / "zap_summary.md"
 
-          def count_alerts(d):
+          def collect_alerts(d):
             alerts = []
             if isinstance(d, dict):
-              if "site" in d:
-                for s in d.get("site", []):
+              if isinstance(d.get("site"), list):
+                for s in d["site"]:
                   alerts += s.get("alerts", []) or []
-              if "alerts" in d and isinstance(d["alerts"], list):
+              if isinstance(d.get("alerts"), list):
                 alerts += d["alerts"]
             return alerts
 
-          summary = []
-          summary.append("# ZAP baseline summary\n")
-
-          total = 0
           sev = {"High": 0, "Medium": 0, "Low": 0, "Informational": 0, "Unknown": 0}
+          total = 0
           top = []
+
+          lines = ["# ZAP baseline summary", ""]
+          lines.append(f"**Target:** `{os.environ.get('TARGET_URL','')}`")
 
           if report_path.exists():
             try:
               data = json.loads(report_path.read_text(encoding="utf-8"))
-              alerts = count_alerts(data)
+              alerts = collect_alerts(data)
               total = len(alerts)
-
               for a in alerts:
                 risk = (a.get("risk") or a.get("riskdesc") or "").strip()
-                if risk:
-                  risk = risk.split()[0]
+                risk = risk.split()[0] if risk else "Unknown"
                 if risk not in sev:
                   risk = "Unknown"
                 sev[risk] += 1
-
               for a in alerts[:5]:
                 name = a.get("name") or a.get("alert") or "Unknown alert"
                 risk = (a.get("risk") or a.get("riskdesc") or "").strip()
-                if risk:
-                  risk = risk.split()[0]
-                if not risk:
-                  risk = "Unknown"
+                risk = risk.split()[0] if risk else "Unknown"
                 top.append((risk, name))
-
             except Exception as e:
-              summary.append(f"Не удалось распарсить zap_baseline.json: {e}\n")
+              lines += ["", f"Не удалось распарсить zap_baseline.json: {e}"]
           else:
-            summary.append("Отчёт zap_baseline.json не найден.\n")
+            lines += ["", "Отчёт zap_baseline.json не найден."]
 
-          summary.append(f"**Target:** `{os.environ.get('TARGET_URL','')}`")
-          summary.append(f"**Всего алертов:** {total}\n")
-          summary.append("## Распределение по severity\n")
-          summary.append(f"- High: {sev['High']}")
-          summary.append(f"- Medium: {sev['Medium']}")
-          summary.append(f"- Low: {sev['Low']}")
-          summary.append(f"- Informational: {sev['Informational']}")
-          summary.append(f"- Unknown: {sev['Unknown']}\n")
+          lines += ["", f"**Всего алертов:** {total}", "", "## Распределение по severity", ""]
+          lines += [f"- High: {sev['High']}", f"- Medium: {sev['Medium']}", f"- Low: {sev['Low']}",
+                    f"- Informational: {sev['Informational']}", f"- Unknown: {sev['Unknown']}", ""]
 
           if top:
-            summary.append("## Примеры алертов (первые 5)\n")
-            for risk, name in top:
-              summary.append(f"- {risk}: {name}")
-            summary.append("")
+            lines += ["## Примеры алертов (первые 5)", ""]
+            lines += [f"- {r}: {n}" for r, n in top]
+            lines.append("")
 
-          sha = os.environ.get("GITHUB_SHA", "")
-          run_url = os.environ.get("GITHUB_RUN_URL", "")
-          summary.append("---")
-          if sha:
-            summary.append(f"Commit: `{sha}`")
-          if run_url:
-            summary.append(f"Workflow run: {run_url}")
-          summary.append("")
+          lines += ["---",
+                    f"Commit: `{os.environ.get('GITHUB_SHA','')}`",
+                    f"Run: {os.environ.get('GITHUB_SERVER_URL','')}/{os.environ.get('GITHUB_REPOSITORY','')}/actions/runs/{os.environ.get('GITHUB_RUN_ID','')}",
+                    ""]
 
-          out_path.write_text("\n".join(summary), encoding="utf-8")
+          out_path.write_text("\n".join(lines), encoding="utf-8")
           PY
 
-      - name: Upload ZAP evidence
+      - name: Collect compose logs
+        if: always()
+        run: |
+          docker compose ps || true
+          docker compose logs --no-color > EVIDENCE/P11/compose.log || true
+
+      - name: Upload P11 evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: P11_EVIDENCE
           path: EVIDENCE/P11
-
-      - name: Show compose status & logs
-        if: always()
-        run: |
-          docker compose ps || true
-          docker compose logs --no-color || true
 
       - name: Docker Compose down
         if: always()

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -8,11 +8,12 @@ on:
       - "Dockerfile"
       - "docker-compose.yml"
       - "scripts/**"
-      - ".github/workflows/ci-p11-dast.yml"
       - ".env.example"
+      - ".github/workflows/ci-p11-dast.yml"
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,11 +22,17 @@ concurrency:
 jobs:
   dast_zap:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
+
     env:
-      TARGET_URL: http://localhost:8000
+      BASE_URL: http://localhost:8000
       HEALTH_URL: http://localhost:8000/health
+
       JWT_SECRET_KEY: jwt-secret-ci-demo-key-0123456789012345678901234567
+
+      ZAP_TARGET: http://localhost:8000/docs
+
+      ZAP_IMAGE: ghcr.io/zaproxy/zaproxy:stable
 
     steps:
       - name: Checkout
@@ -41,7 +48,9 @@ jobs:
             echo
             echo "Commit: \`${GITHUB_SHA}\`"
             echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            echo "Target: ${TARGET_URL}"
+            echo "BASE_URL: ${BASE_URL}"
+            echo "ZAP_TARGET: ${ZAP_TARGET}"
+            echo "ZAP_IMAGE: ${ZAP_IMAGE}"
           } > EVIDENCE/P11/ci_debug.md
 
       - name: Prepare .env for compose (CI)
@@ -85,31 +94,35 @@ jobs:
             echo "Attempt ${i}/40: not ready yet"
             sleep 3
           done
-          echo "Service did not become ready in time"
+          echo "Service did not become ready"
           docker compose logs --no-color
           exit 1
 
-      - name: Smoke test target
+      - name: Smoke test base endpoints
         run: |
           set -euo pipefail
-          curl -fsS "${TARGET_URL}/health"
+          curl -fsS "${BASE_URL}/health" > /dev/null
+          curl -fsS "${BASE_URL}/docs" > /dev/null || true
 
-      - name: Ensure evidence dir perms
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull ZAP image (GHCR)
         run: |
-          mkdir -p EVIDENCE/P11
-          chmod -R a+rwx EVIDENCE/P11
+          set -euo pipefail
+          docker pull "${ZAP_IMAGE}"
 
       - name: Run OWASP ZAP baseline
         run: |
           set -euo pipefail
-
-          ZAP_IMAGE="owasp/zap2docker-stable"
-
-          docker pull "${ZAP_IMAGE}"
-
           mkdir -p EVIDENCE/P11
           chmod -R a+rwx EVIDENCE/P11
 
+          set +e
           docker run --rm \
             --network host \
             -u "$(id -u):$(id -g)" \
@@ -117,18 +130,16 @@ jobs:
             -w /zap/wrk \
             "${ZAP_IMAGE}" \
             zap-baseline.py \
-              -t "${TARGET_URL}" \
+              -t "${ZAP_TARGET}" \
               -r /zap/wrk/EVIDENCE/P11/zap_baseline.html \
               -J /zap/wrk/EVIDENCE/P11/zap_baseline.json \
-              -m 5 \
-              -T 10 \
-            2>&1 | tee EVIDENCE/P11/zap_baseline.log || true
+              -m 8 \
+              -T 15 \
+            2>&1 | tee EVIDENCE/P11/zap_baseline.log
+          set -e
 
           test -s EVIDENCE/P11/zap_baseline.html
           test -s EVIDENCE/P11/zap_baseline.json
-
-
-
 
       - name: Generate ZAP summary (markdown)
         run: |
@@ -151,47 +162,47 @@ jobs:
             return alerts
 
           sev = {"High": 0, "Medium": 0, "Low": 0, "Informational": 0, "Unknown": 0}
-          total = 0
           top = []
+          total = 0
 
-          lines = ["# ZAP baseline summary", ""]
-          lines.append(f"**Target:** `{os.environ.get('TARGET_URL','')}`")
+          data = json.loads(report_path.read_text(encoding="utf-8"))
+          alerts = collect_alerts(data)
+          total = len(alerts)
 
-          if report_path.exists():
-            try:
-              data = json.loads(report_path.read_text(encoding="utf-8"))
-              alerts = collect_alerts(data)
-              total = len(alerts)
-              for a in alerts:
-                risk = (a.get("risk") or a.get("riskdesc") or "").strip()
-                risk = risk.split()[0] if risk else "Unknown"
-                if risk not in sev:
-                  risk = "Unknown"
-                sev[risk] += 1
-              for a in alerts[:5]:
-                name = a.get("name") or a.get("alert") or "Unknown alert"
-                risk = (a.get("risk") or a.get("riskdesc") or "").strip()
-                risk = risk.split()[0] if risk else "Unknown"
-                top.append((risk, name))
-            except Exception as e:
-              lines += ["", f"Не удалось распарсить zap_baseline.json: {e}"]
-          else:
-            lines += ["", "Отчёт zap_baseline.json не найден."]
+          for a in alerts:
+            risk = (a.get("risk") or a.get("riskdesc") or "").strip()
+            risk = risk.split()[0] if risk else "Unknown"
+            if risk not in sev:
+              risk = "Unknown"
+            sev[risk] += 1
 
-          lines += ["", f"**Всего алертов:** {total}", "", "## Распределение по severity", ""]
-          lines += [f"- High: {sev['High']}", f"- Medium: {sev['Medium']}", f"- Low: {sev['Low']}",
-                    f"- Informational: {sev['Informational']}", f"- Unknown: {sev['Unknown']}", ""]
+          for a in alerts[:5]:
+            name = a.get("name") or a.get("alert") or "Unknown alert"
+            risk = (a.get("risk") or a.get("riskdesc") or "").strip()
+            risk = risk.split()[0] if risk else "Unknown"
+            top.append((risk, name))
+
+          lines = []
+          lines.append("# ZAP baseline summary\n")
+          lines.append(f"**Target:** `{os.environ.get('ZAP_TARGET','')}`")
+          lines.append(f"**Всего алертов:** {total}\n")
+          lines.append("## Распределение по severity\n")
+          lines.append(f"- High: {sev['High']}")
+          lines.append(f"- Medium: {sev['Medium']}")
+          lines.append(f"- Low: {sev['Low']}")
+          lines.append(f"- Informational: {sev['Informational']}")
+          lines.append(f"- Unknown: {sev['Unknown']}\n")
 
           if top:
-            lines += ["## Примеры алертов (первые 5)", ""]
-            lines += [f"- {r}: {n}" for r, n in top]
+            lines.append("## Примеры алертов (первые 5)\n")
+            for r, n in top:
+              lines.append(f"- {r}: {n}")
             lines.append("")
 
-          lines += ["---",
-                    f"Commit: `{os.environ.get('GITHUB_SHA','')}`",
-                    f"Run: {os.environ.get('GITHUB_SERVER_URL','')}/{os.environ.get('GITHUB_REPOSITORY','')}/actions/runs/{os.environ.get('GITHUB_RUN_ID','')}",
-                    ""]
-
+          lines.append("---")
+          lines.append(f"Commit: `{os.environ.get('GITHUB_SHA','')}`")
+          lines.append(f"Run: {os.environ.get('GITHUB_SERVER_URL','')}/{os.environ.get('GITHUB_REPOSITORY','')}/actions/runs/{os.environ.get('GITHUB_RUN_ID','')}")
+          lines.append("")
           out_path.write_text("\n".join(lines), encoding="utf-8")
           PY
 

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -99,15 +99,17 @@ jobs:
           mkdir -p EVIDENCE/P11
           chmod -R a+rwx EVIDENCE/P11
 
-      - name: Run OWASP ZAP baseline (Docker Hub)
+      - name: Run OWASP ZAP baseline
         run: |
           set -euo pipefail
 
-          ZAP_IMAGE="zaproxy/zap2docker-stable"
+          ZAP_IMAGE="owasp/zap2docker-stable"
 
           docker pull "${ZAP_IMAGE}"
 
-          set +e
+          mkdir -p EVIDENCE/P11
+          chmod -R a+rwx EVIDENCE/P11
+
           docker run --rm \
             --network host \
             -u "$(id -u):$(id -g)" \
@@ -120,14 +122,11 @@ jobs:
               -J /zap/wrk/EVIDENCE/P11/zap_baseline.json \
               -m 5 \
               -T 10 \
-            2>&1 | tee EVIDENCE/P11/zap_baseline.log
-          rc=${PIPESTATUS[0]}
-          set -e
+            2>&1 | tee EVIDENCE/P11/zap_baseline.log || true
 
           test -s EVIDENCE/P11/zap_baseline.html
           test -s EVIDENCE/P11/zap_baseline.json
 
-          exit 0
 
 
 

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -99,22 +99,36 @@ jobs:
           mkdir -p EVIDENCE/P11
           chmod -R a+rwx EVIDENCE/P11
 
-      - name: Run OWASP ZAP baseline
+      - name: Run OWASP ZAP baseline (Docker Hub)
         run: |
           set -euo pipefail
+
+          ZAP_IMAGE="zaproxy/zap2docker-stable"
+
+          docker pull "${ZAP_IMAGE}"
+
+          set +e
           docker run --rm \
             --network host \
             -u "$(id -u):$(id -g)" \
             -v "$PWD:/zap/wrk" \
             -w /zap/wrk \
-            ghcr.io/zaproxy/zap2docker-stable \
+            "${ZAP_IMAGE}" \
             zap-baseline.py \
               -t "${TARGET_URL}" \
               -r /zap/wrk/EVIDENCE/P11/zap_baseline.html \
               -J /zap/wrk/EVIDENCE/P11/zap_baseline.json \
               -m 5 \
               -T 10 \
-            2>&1 | tee EVIDENCE/P11/zap_baseline.log || true
+            2>&1 | tee EVIDENCE/P11/zap_baseline.log
+          rc=${PIPESTATUS[0]}
+          set -e
+
+          test -s EVIDENCE/P11/zap_baseline.html
+          test -s EVIDENCE/P11/zap_baseline.json
+
+          exit 0
+
 
 
       - name: Generate ZAP summary (markdown)

--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -1,4 +1,4 @@
-name: Security - DAST (OWASP ZAP Baseline)
+name: Security - DAST (P11 ZAP)
 
 on:
   workflow_dispatch:
@@ -20,43 +20,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  dast_zap:
+  zap_p11:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
     env:
-      BASE_URL: http://localhost:8000
-      HEALTH_URL: http://localhost:8000/health
-
+      PUBLIC_URL: http://localhost:8000
+      READY_URL: http://localhost:8000/health
       JWT_SECRET_KEY: jwt-secret-ci-demo-key-0123456789012345678901234567
-
-      ZAP_TARGET: http://localhost:8000/docs
-
       ZAP_IMAGE: ghcr.io/zaproxy/zaproxy:stable
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Ensure evidence dir
-        run: mkdir -p EVIDENCE/P11
-
-      - name: Write CI debug metadata
+      - name: Prepare evidence
         run: |
+          mkdir -p EVIDENCE/P11
           {
-            echo "# P11 CI debug"
+            echo "# P11 run"
             echo
             echo "Commit: \`${GITHUB_SHA}\`"
             echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            echo "BASE_URL: ${BASE_URL}"
-            echo "ZAP_TARGET: ${ZAP_TARGET}"
-            echo "ZAP_IMAGE: ${ZAP_IMAGE}"
+            echo "Public URL: ${PUBLIC_URL}"
           } > EVIDENCE/P11/ci_debug.md
 
-      - name: Prepare .env for compose (CI)
+      - name: Compose env
         run: |
           set -euo pipefail
-
           if [ -f .env.example ]; then
             cp .env.example .env
           else
@@ -73,130 +62,132 @@ jobs:
             echo "DATABASE_URL=sqlite:////data/parking.db" >> .env
           fi
 
-          echo "Prepared .env (keys only):"
-          grep -E '^(JWT_SECRET_KEY|DATABASE_URL)=' .env | sed 's/JWT_SECRET_KEY=.*/JWT_SECRET_KEY=***masked***/'
-
-      - name: Build & start service (docker compose)
+      - name: Start stack
         run: |
           set -euo pipefail
           docker compose up -d --build
           docker compose ps
 
-      - name: Wait for service readiness (healthcheck)
+      - name: Wait readiness
         run: |
           set -euo pipefail
-          echo "Waiting for ${HEALTH_URL}..."
           for i in {1..40}; do
-            if curl -fsS "${HEALTH_URL}" > /dev/null; then
-              echo "Service is ready"
+            if curl -fsS "${READY_URL}" > /dev/null; then
               exit 0
             fi
-            echo "Attempt ${i}/40: not ready yet"
             sleep 3
           done
-          echo "Service did not become ready"
           docker compose logs --no-color
           exit 1
 
-      - name: Smoke test base endpoints
-        run: |
-          set -euo pipefail
-          curl -fsS "${BASE_URL}/health" > /dev/null
-          curl -fsS "${BASE_URL}/docs" > /dev/null || true
-
-      - name: Login to GHCR
+      - name: Login ghcr
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull ZAP image (GHCR)
+      - name: Pull zap image
         run: |
           set -euo pipefail
-          docker pull "${ZAP_IMAGE}"
+          for i in 1 2 3; do
+            docker pull "${ZAP_IMAGE}" && break
+            sleep 5
+          done
+          docker image inspect "${ZAP_IMAGE}" > /dev/null
 
-      - name: Run OWASP ZAP baseline
+      - name: Run ZAP quick scan
         run: |
           set -euo pipefail
-          mkdir -p EVIDENCE/P11
-          chmod -R a+rwx EVIDENCE/P11
 
-          set +e
+          cid="$(docker compose ps -q api)"
+          if [ -z "${cid}" ]; then
+            docker compose ps
+            exit 1
+          fi
+
+          net="$(docker inspect "${cid}" --format='{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{"\n"}}{{end}}' | head -1)"
+          if [ -z "${net}" ]; then
+            docker inspect "${cid}" --format='{{json .NetworkSettings.Networks}}'
+            exit 1
+          fi
+          docker network inspect "${net}" > /dev/null
+
+          chmod 777 EVIDENCE/P11
+
+          start="/docs"
+          if ! docker run --rm --network "${net}" curlimages/curl:8.10.1 -fsS "http://api:8000/docs" > /dev/null; then
+            start="/"
+          fi
+          echo "target=http://api:8000${start}" > EVIDENCE/P11/target.txt
+
           docker run --rm \
-            --network host \
-            -e HOME=/zap/wrk \
-            -u "$(id -u):$(id -g)" \
-            -v "$PWD:/zap/wrk" \
-            -w /zap/wrk \
+            --user 0 \
+            --network "${net}" \
+            -v "$PWD/EVIDENCE/P11:/zap/wrk/:rw" \
             "${ZAP_IMAGE}" \
-            zap-baseline.py \
-              -t "${ZAP_TARGET}" \
-              -r /zap/wrk/EVIDENCE/P11/zap_baseline.html \
-              -J /zap/wrk/EVIDENCE/P11/zap_baseline.json \
-              -m 8 \
-              -T 15 \
-            2>&1 | tee EVIDENCE/P11/zap_baseline.log
-          set -e
+            zap.sh -cmd -quickurl "http://api:8000${start}" -quickout /zap/wrk/zap_baseline.html -quickprogress || true
+
+          docker run --rm \
+            --user 0 \
+            --network "${net}" \
+            -v "$PWD/EVIDENCE/P11:/zap/wrk/:rw" \
+            "${ZAP_IMAGE}" \
+            zap.sh -cmd -quickurl "http://api:8000${start}" -quickout /zap/wrk/zap_baseline.json -quickprogress || true
 
           test -s EVIDENCE/P11/zap_baseline.html
           test -s EVIDENCE/P11/zap_baseline.json
 
-      - name: Generate ZAP summary (markdown)
+      - name: Build summary
         run: |
           python - << 'PY'
           import json, os
           from pathlib import Path
 
           evidence = Path("EVIDENCE/P11")
-          report_path = evidence / "zap_baseline.json"
-          out_path = evidence / "zap_summary.md"
+          src = evidence / "zap_baseline.json"
+          out = evidence / "zap_summary.md"
 
-          def collect_alerts(d):
-            alerts = []
-            if isinstance(d, dict):
-              if isinstance(d.get("site"), list):
-                for s in d["site"]:
-                  alerts += s.get("alerts", []) or []
-              if isinstance(d.get("alerts"), list):
-                alerts += d["alerts"]
-            return alerts
+          raw = json.loads(src.read_text(encoding="utf-8"))
+          alerts = []
+          if isinstance(raw, dict):
+            if isinstance(raw.get("site"), list):
+              for s in raw["site"]:
+                alerts += s.get("alerts", []) or []
+            elif isinstance(raw.get("alerts"), list):
+              alerts = raw["alerts"]
 
-          sev = {"High": 0, "Medium": 0, "Low": 0, "Informational": 0, "Unknown": 0}
-          top = []
-          total = 0
-
-          data = json.loads(report_path.read_text(encoding="utf-8"))
-          alerts = collect_alerts(data)
-          total = len(alerts)
-
+          levels = {"High": 0, "Medium": 0, "Low": 0, "Informational": 0, "Unknown": 0}
           for a in alerts:
             risk = (a.get("risk") or a.get("riskdesc") or "").strip()
             risk = risk.split()[0] if risk else "Unknown"
-            if risk not in sev:
+            if risk not in levels:
               risk = "Unknown"
-            sev[risk] += 1
+            levels[risk] += 1
 
+          sample = []
           for a in alerts[:5]:
             name = a.get("name") or a.get("alert") or "Unknown alert"
             risk = (a.get("risk") or a.get("riskdesc") or "").strip()
             risk = risk.split()[0] if risk else "Unknown"
-            top.append((risk, name))
+            sample.append((risk, name))
 
           lines = []
-          lines.append("# ZAP baseline summary\n")
-          lines.append(f"**Target:** `{os.environ.get('ZAP_TARGET','')}`")
-          lines.append(f"**Всего алертов:** {total}\n")
-          lines.append("## Распределение по severity\n")
-          lines.append(f"- High: {sev['High']}")
-          lines.append(f"- Medium: {sev['Medium']}")
-          lines.append(f"- Low: {sev['Low']}")
-          lines.append(f"- Informational: {sev['Informational']}")
-          lines.append(f"- Unknown: {sev['Unknown']}\n")
+          lines.append("# ZAP summary\n")
+          t = (evidence / "target.txt").read_text(encoding="utf-8").strip() if (evidence / "target.txt").exists() else ""
+          if t:
+            lines.append(f"**Target:** `{t}`\n")
+          lines.append(f"**Total:** {len(alerts)}\n")
+          lines.append("## Severity\n")
+          lines.append(f"- High: {levels['High']}")
+          lines.append(f"- Medium: {levels['Medium']}")
+          lines.append(f"- Low: {levels['Low']}")
+          lines.append(f"- Informational: {levels['Informational']}")
+          lines.append(f"- Unknown: {levels['Unknown']}\n")
 
-          if top:
-            lines.append("## Примеры алертов (первые 5)\n")
-            for r, n in top:
+          if sample:
+            lines.append("## Examples\n")
+            for r, n in sample:
               lines.append(f"- {r}: {n}")
             lines.append("")
 
@@ -204,22 +195,23 @@ jobs:
           lines.append(f"Commit: `{os.environ.get('GITHUB_SHA','')}`")
           lines.append(f"Run: {os.environ.get('GITHUB_SERVER_URL','')}/{os.environ.get('GITHUB_REPOSITORY','')}/actions/runs/{os.environ.get('GITHUB_RUN_ID','')}")
           lines.append("")
-          out_path.write_text("\n".join(lines), encoding="utf-8")
+          out.write_text("\n".join(lines), encoding="utf-8")
           PY
 
-      - name: Collect compose logs
+      - name: Collect logs
         if: always()
         run: |
           docker compose ps || true
           docker compose logs --no-color > EVIDENCE/P11/compose.log || true
 
-      - name: Upload P11 evidence
+      - name: Upload evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: P11_EVIDENCE
           path: EVIDENCE/P11
+          retention-days: 30
 
-      - name: Docker Compose down
+      - name: Teardown
         if: always()
         run: docker compose down -v || true

--- a/EVIDENCE/P11/ci_debug.md
+++ b/EVIDENCE/P11/ci_debug.md
@@ -1,0 +1,5 @@
+# P11 run
+
+Commit: `0ca59df24ea6321f98ffde90913b1f6d04da522e`
+Run: https://github.com/Mushkat/Mushkat-secdev-2025/actions/runs/20205602086
+Public URL: http://localhost:8000

--- a/EVIDENCE/P11/compose.log
+++ b/EVIDENCE/P11/compose.log
@@ -1,0 +1,204 @@
+api-1  | INFO:     Started server process [1]
+api-1  | INFO:     Waiting for application startup.
+api-1  | INFO:     Application startup complete.
+api-1  | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+api-1  | INFO:     172.18.0.1:58164 - "GET /health HTTP/1.1" 200 OK
+api-1  | INFO:     127.0.0.1:44268 - "GET /health HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60796 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60808 - "GET /robots.txt HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /sitemap.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     127.0.0.1:46498 - "GET /health HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /8047204569361399211 HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /WEB-INF/web.xml HTTP/1.1" 404 Not Found
+api-1  | WARNING:  Invalid HTTP request received.
+api-1  | INFO:     172.18.0.3:60802 - "GET /WEB-INF/applicationContext.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60808 - "GET /docs?-s HTTP/1.1" 200 OK
+api-1  | WARNING:  Invalid HTTP request received.
+api-1  | WARNING:  Invalid HTTP request received.
+api-1  | INFO:     172.18.0.3:60802 - "POST /docs?-d+allow_url_include%3d1+-d+auto_prepend_file%3dphp://input HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:60802 - "POST /docs?-d+allow_url_include%3d1+-d+auto_prepend_file%3dphp://input HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs?class.module.classLoader.DefaultAssertionStatus=nonsense HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "POST /docs HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:60802 - "POST /docs HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:60802 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /computeMetadata/v1/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /computeMetadata/v1/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /opc/v1/instance/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /opc/v1/instance/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /metadata/instance HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs/ HTTP/1.1" 307 Temporary Redirect
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /trace.axd HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60808 - "GET /elmah.axd HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60808 - "GET /.htaccess HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60808 - "GET /.env HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60808 - "GET /zap7691606160416983364 HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /actuator/health HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60808 - "GET /.zap1185576988375045462 HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /actuator/health HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /lfm.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.idea/WebServers.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /config/databases.yml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /config/database.yml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.git/config HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.svn/entries HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.svn/wc.db HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /CVS/root HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /server-status HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /core HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /sftp-config.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /WS_FTP.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /ws_ftp.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /WS_FTP.INI HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /filezilla.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /sitemanager.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /FileZilla.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /winscp.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /WinSCP.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.DS_Store HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.php_cs.cache HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /DEADJOE HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /sites/default/private/files/backup_migrate/scheduled/test.txt HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /app/etc/local.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /server.key HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /privatekey.key HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /myserver.key HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /key.pem HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /id_rsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /id_dsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.ssh/id_rsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.ssh/id_dsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /adminer.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /vb_test.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /CHANGELOG.txt HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /sites/default/files/.ht.sqlite HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /composer.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /composer.lock HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /vim_settings.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /server-info HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /phpinfo.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /info.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /i.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /test.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /_wpeprivate/config.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /_framework/blazor.boot.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.hg HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /.bzr HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /._darcs HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /BitKeeper HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:60802 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51810 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51810 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51810 - "GET /robots.txt HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /sitemap.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /6049744010189962386 HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /WEB-INF/web.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /WEB-INF/applicationContext.xml HTTP/1.1" 404 Not Found
+api-1  | WARNING:  Invalid HTTP request received.
+api-1  | WARNING:  Invalid HTTP request received.
+api-1  | WARNING:  Invalid HTTP request received.
+api-1  | INFO:     172.18.0.3:51810 - "GET /docs?-s HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51810 - "POST /docs?-d+allow_url_include%3d1+-d+auto_prepend_file%3dphp://input HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:51810 - "POST /docs?-d+allow_url_include%3d1+-d+auto_prepend_file%3dphp://input HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:51810 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51810 - "GET /docs?class.module.classLoader.DefaultAssertionStatus=nonsense HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51810 - "POST /docs HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:51810 - "POST /docs HTTP/1.1" 405 Method Not Allowed
+api-1  | INFO:     172.18.0.3:51810 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /computeMetadata/v1/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /computeMetadata/v1/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /opc/v1/instance/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /opc/v1/instance/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /latest/meta-data/ HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /metadata/instance HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /docs/ HTTP/1.1" 307 Temporary Redirect
+api-1  | INFO:     172.18.0.3:51810 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51810 - "GET /elmah.axd HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /trace.axd HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /.htaccess HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /.env HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /zap2185863863669472590 HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /actuator/health HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51810 - "GET /actuator/health HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.zap7887396096237078583 HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /lfm.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.idea/WebServers.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /config/databases.yml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /config/database.yml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.git/config HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.svn/entries HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.svn/wc.db HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /CVS/root HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /server-status HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /core HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /sftp-config.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /WS_FTP.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /ws_ftp.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /WS_FTP.INI HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /filezilla.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /sitemanager.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /FileZilla.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /winscp.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /WinSCP.ini HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.DS_Store HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.php_cs.cache HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /DEADJOE HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /sites/default/private/files/backup_migrate/scheduled/test.txt HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /app/etc/local.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /server.key HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /privatekey.key HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /myserver.key HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /key.pem HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /id_rsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /id_dsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.ssh/id_rsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.ssh/id_dsa HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /adminer.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /vb_test.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /CHANGELOG.txt HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /sites/default/files/.ht.sqlite HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /composer.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /composer.lock HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /vim_settings.xml HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /server-info HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /phpinfo.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /info.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /i.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /test.php HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /_wpeprivate/config.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /_framework/blazor.boot.json HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.hg HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /.bzr HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /._darcs HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /BitKeeper HTTP/1.1" 404 Not Found
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK
+api-1  | INFO:     172.18.0.3:51858 - "GET /docs HTTP/1.1" 200 OK

--- a/EVIDENCE/P11/target.txt
+++ b/EVIDENCE/P11/target.txt
@@ -1,0 +1,1 @@
+target=http://api:8000/docs

--- a/EVIDENCE/P11/zap_baseline.html
+++ b/EVIDENCE/P11/zap_baseline.html
@@ -1,0 +1,821 @@
+<!DOCTYPE html>
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>ZAP Report</title>
+<style type="text/css">
+body {
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	color: #000;
+	font-size: 13px;
+}
+
+h1 {
+	text-align: center;
+	font-weight: bold;
+	font-size: 32px
+}
+
+h3 {
+	font-size: 16px;
+}
+
+table {
+	border: none;
+	font-size: 13px;
+}
+
+td, th {
+	padding: 3px 4px;
+	word-break: break-word;
+}
+
+th {
+	font-weight: bold;
+	background-color: #666666;
+}
+
+td {
+	background-color: #e8e8e8;
+}
+
+.spacer {
+	margin: 10px;
+}
+
+.spacer-lg {
+	margin: 40px;
+}
+
+.indent1 {
+	padding: 4px 20px;
+}
+
+.indent2 {
+	padding: 4px 40px;
+}
+
+.risk-3 {
+	background-color: red;
+	color: #FFF;
+}
+
+.risk-2 {
+	background-color: orange;
+	color: #FFF;
+}
+
+.risk-1 {
+	background-color: yellow;
+	color: #000;
+}
+
+.risk-0 {
+	background-color: blue;
+	color: #FFF;
+}
+
+.risk--1 {
+	background-color: green;
+	color: #FFF;
+}
+
+.summary {
+	width: 45%;
+}
+
+.summary th {
+	color: #FFF;
+}
+
+.summary100 {
+	width: 100%;
+}
+
+.summary80 {
+	width: 80%;
+}
+
+.tdconstrainer {
+	width: 9.1%;
+	padding: 0
+}
+
+.alerts {
+	width: 75%;
+}
+
+.alerts th {
+	color: #FFF;
+}
+
+.results {
+	width: 100%;
+}
+
+.results th {
+	text-align: left;
+}
+
+.left-header {
+	display: inline-block;
+}
+
+.pass {
+	background: green;
+	color: white
+}
+
+.pass::before {
+	content: '\2714';
+	color: white
+}
+
+.fail {
+	background: red;
+	color: white
+}
+
+.fail::before {
+	content: '\2716';
+	color: white
+}
+
+.alert-3b::before {
+	content: '\2691';
+	color: red
+}
+
+.alert-2b::before {
+	content: '\2691 ';
+	color: orange
+}
+
+.alert-1b::before {
+	content: '\2691';
+	color: yellow
+}
+
+.alert-0b::before {
+	content: '\2691';
+	color: blue
+}
+
+.alert-3a::after {
+	content: '\2691';
+	color: red
+}
+
+.alert-2a::after {
+	content: '\2691 ';
+	color: orange
+}
+
+.alert-1a::after {
+	content: '\2691';
+	color: yellow
+}
+
+.alert-0a::after {
+	content: '\2691';
+	color: blue
+}
+
+.lm2 {
+	margin-left: 2em;
+}
+
+.smallnote {
+	font-size: 0.75em
+}
+
+.alwayswhite {
+	color: white
+}
+</style>
+</head>
+<body>
+	<h1>
+		<!-- The ZAP by Checkmark Logo -->
+		<img
+			src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANcAAABHCAYAAACUG9L2AAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9bRS0VEQuKOGSoThbEijhqFYpQIdQKrTqYXPoFTRqSFBdHwbXg4Mdi1cHFWVcHV0EQ/ABxdnBSdJES/5cUWsR4cNyPd/ced+8Af73MVLNjAlA1y0gl4kImuyp0vaIH/QhiEDGJmfqcKCbhOb7u4ePrXZRneZ/7c/QqOZMBPoF4lumGRbxBPL1p6Zz3icOsKCnE58TjBl2Q+JHrsstvnAsO+3lm2Ein5onDxEKhjeU2ZkVDJZ4ijiiqRvn+jMsK5y3OarnKmvfkLwzltJVlrtMcQQKLWIIIATKqKKEMC1FaNVJMpGg/7uEfdvwiuWRylcDIsYAKVEiOH/wPfndr5mOTblIoDnS+2PbHKNC1CzRqtv19bNuNEyDwDFxpLX+lDsx8kl5raZEjoG8buLhuafIecLkDDD3pkiE5UoCmP58H3s/om7LAwC0QXHN7a+7j9AFIU1fJG+DgEBgrUPa6x7u723v790yzvx+G9XKvRbkt4gAAAAZiS0dEAAAAAAAA+UO7fwAAAAlwSFlzAAAN1wAADdcBQiibeAAAAAd0SU1FB+gJEQobFG0N+/UAACAASURBVHja7Z13fBTl1se/ZzadANlNAClSBBEEG8UKiIrYwAIEFK+AtKj3tVy7V4KRgOLlxXqVK11AwYSiIpZXxY5X7FdU7KAUgWQ3jRSy+zzvH7NltoUkJJTrnnwmMzszO3tm5vk9pzznOQcODTmA4wGDGMUoRgdMNuByYD2gvctm4LjYo4lRjOpHzYCbgV8soLIuPwKpsccUoxjVnroDc4AyK5gMw9g1YsSIt4cOHfquZf9TsccVoxjVTAYwCFgLKCuoUlNTv7vnnnveKy8vL9daa6WUateu3Sfe4woYEnt8MfpvImmg6zQFrgJu8UosH3mOPvroz2fPnm3LzMzsFfqlX7b8VnLssV3jlbsqmfiUarlg2jaS05KAJkACsBcoRlOskZ/R6nvTTrNtYNX4X2KvL0b/zeDqDEwCsoA0/0VFCgYPHvzVnDlzunfq1KlNTRf4+//O48E7Jpvfa30iRv9bCDgRtf887fuvQZvCcKvWej3o1RTseI13ctyx1xmj/wZw9QNuAoZhegEBaNKkyfc33XTT7ilTpvROSUlJqe3FjjtrCD9sWAeAre+1GJ3PtRz1wkpbt01tU6NBazTs1kovJ87zBM9n/Rx7rTE60sCVCoz2gqqHZb86+uijP/OqfqfUB7C7ncUc3eV49rl2gC2RhAsfQJq1jiC9giRXAGTaBJrW2qOVeh70A6ya/E3s9cbocAfXMcBkr/rnsKh+JQMGDPhywYIFx3Tu3LndgTKy9MW3GDPsAlAeDMcxJF4wHQxbAFx+UAVLriCAaY1GobVWWnmeJUHfyvKsgthrjtHhBi6f6ncFEOfbmZiYuGXSpEm/zZw5s3eTJk2aNCQz5426gfV5cwCIP2EECSddGWJxhUsuv2oYABZaK9+x3Vp7bmbl5BWxVx2jQw2uRGAUcDtwglX1a9my5ZczZ870jBs3ro+ISGMwU1lVzVHHnkzx79+CCCmDc7G16hHiyCBMHSQIWMEgU1qhlWcpKUnXs3TM3tgrj9GhANd4YFaI6lc8YMCAjXPnzu3UtWvXLgeDoXc+/g/n9jsN7a7EaHoUqUMfReKTwyVXwM7yflZBwFJaBSSYVmjt+VrHuS9lxfVbYq89RgeDfJ6+/sAaIMWr+v3y17/+9ZM33nijXVZW1vHp6emOg8VQx3at+K0sni82vIneV4auLCKxw5kIBiKCiIEg5rZ/7e0nRPz9hfj+/LulFcq4kh5D3uLbtX/EXn2MDpbkmg3cClQsW7bs69GjR/dtLNWvttT+pHP4/T/vAND03HtJ6NgviuRSAQlmlVQor1ro2+9VEbWnSHv0Raye9O8GZ/rqZc1ITO5t6bTqTwabmT98W52+M2llDzzSOuQN/8iC4Vvr/PtjV3TGFt9pv+dpj0KzhwRbARQUMDerOgarYHDdD0wF9M033/z+I4880v9Qg+uHLTvo0fME3HudGInNsA/7F5KS7rW1CKiCocAioA4GVEPl3/YCrFgrPYBVk/7ToExPyJ+HZmJDmaDEJaUzd2h5rc6+Nn8IwtoIR6pQcjKLR2yu9S9fm9cCkR1WR1YtqQrNeyAvY6hlLBjp/DODyxcKsRAoBuSxxx4b0LZt20927ty561Ay1rVjG2bMngMIqqqE0vdmYxgGhti8awPDsJmfxWZue4+L2BDxniOGfzuwtjUXQ9Zx5cKjG5RpTcsGvFoSldXJdegm/xblSCKGvqFuxoLKqAewzN8Szkf0Y2j5lfErJ8XABVuBszHnV7Fz585T27VrZyxZsuTjQ8ncnVkj6T34agD2bf+Mik0vBABlmCAKgC0UVL7PtigAM9qJR68iMy/hiH+LE1Z1AAbWpLBy4yuJB5mrZqDnMj4/588OLoCvgF7A44BWSrUYO3bsqaeddtr75eXl5YeKwbdWPk1qK9NRWbZxLh7nliCJJYZhAZVlf5DkCgeY1zHSF100swEl184GvHUPFe7aPXetxlDzrG4HFXsvaQCeigFXhKWmuM6pjM8f/GcHF0AF5sTGi4A/ANm4cWP/9PT0PzZ89NGPh4LB5k1TWLT4GcQWj/ZUU7Q+F1GegCroBY5fghkG4l0bRpAqaAGWWLZtt5A5/8KGAVfZLYj0wtB9arUgfRG+jHK1Z8kfWVGLHxVgTBgww6Cqxx3w/cXpE1mY6QhbSnWSeT+siWLXz/gzOzQiUUuvLWb2eGJ4LrrmJttLC/+XOJvtoDN6+YS/8+LCB03v4cmjaX7GX8OcGMGeQY9lENnvyAislXmO9/PPuomtJ4uvrTyoNzU+726QByMc+Ymqqt48+5eSWlyjH8j7IXuXe7UQawoFN0ofzeKR+x+GmLiiO8r2bQRwdWDuyN9qBPr4/HyQ4eEtTR/LgpE//Zkll5V2A0OBW0H2oZXt1SWP0rr7GXz1/ZaDzmj+07m06NwHgNKvVrBvxxdh9lawA8MWYmdJQB20LIYIgtGZMvfdB/WGJuYPBMmN6CUUGVkrYAGIjI2wdynCslBoIMZVjdxXa2zGfVGO9fmzq4XhVgQ8wtm3f0CztgAU/PgJvU45mZzHlhxURuPjbKxbvRxbYipoRdEHj/qdGtE9g7YwO8sLJsuAtH/7TjIXHXVQbmZc3lEonovokdPcyIIRX9TqOpl5yWhGhOzdRfuMN8BYijnD29K+1fhGv7d5I77BTO0QTCpk/C0GLmDUvO7SsttA2/n3YRx7PiCoimLuv2Ucp5x/Jc7isoPGbN8Tu3Du5RNM72HhT+DZF7C3wiSVBUBhi1jW/qiPZHT13xr9JnLejsMmeUCkxraCRZnza32tpjIMyyRVL4KeJeccNwuGbzXHnIKO9WRc3skH4VW5Iwg1IwaucJ/V30XEkLhE4nqPJWHgHUhSc0Dz5ZvP065LT1a/vqFRmfz9j0L+lvs0x/S6kDdX/cvUcVJbYotv4gdVVEllkVIBqeXdZ90WQcR2PZnzGzfU67eCWWj6R1CbfoCEyXX0ToarhEottXwKVy+MiGpkA9qRy9uEAx4QKYiBy0pXPJMuYoz0x/CJYGvTi8QBt3rnWkFFwVZGXDKQ2x94ulEYvGD0bXRo15pHp17Hr1+8jnZXIYaNFgPuiOgZDLanQqQVFiB5t/HHKBoI0hTUNY32tCesvBzTGxtuZ2GMZOFlpbW+1pi8tgjnhoDtGxaPDHgfk3V+BBXtmsYd24u/LXInrb6KgctKtqrRgiRYg2V1yXaq3p4JyuN3OLbs0pveJx7fKAxeNGggqIDpkNZzOB2vXknT4y7yDyJHBlRU2yoEZAJigK8D0UbjgGvSiq5o/QwRPbT6ehYOq1vji5OxhMYwin4m6PNTI8uAF0O+mU6qXNQoEmtC/sOgI6nWv7I4808HrhpDXATjL+KLNPc2QPfmdejqChCDngOGMTPnLi4Z2HiOoFvGD+X9j+5l9fxpptZTVUJSy+5+F7wCDLS5FlBoxLdPQNDmIuZe0ToQUa+9YPPu01pApDfD5/Zo0DQB1yxpgtu2GqFZOK7kORZlLq7PVUMVQgzb8gjnLQGuDnmxYyOArhaWlLzM+Px9oaIKaA+kWTIyhKqE00F0THL56Kp5rRDpS8j0Dl1peogTmrZg3fKnGhVYPsp/Ooeufc20hiU/vkHhx3OjhTTVoAIa+KalBE9XCV9jyNCG1ZRS5iBBeUcCalx8Yt3j78bnnQF0C9n7ZsQo+vbfvAmE7h/CtXkt6nEnJwC9Q5YTI9pYASAvY8HwRRGPTV6bwtXLmv35wLWPcwWRQMMz50jFtT3FPFyyiy7dTuDp5a82PpOG8P6rz9KsVVcAdn/4KHu3fBASyhRN7TOCweOXxOFr/zlazmkw5q9deRPoSKrmXtAjax31HiztxkbYtzSydzJHITwXLm0ae8wLD8I/KNHjokotd+UeEhOLmbDylD8XuETO8VsHgr8Bxh87mPhjBwFQXbKL664ewnmjbqZyX+OmDWyZ3owXX3yBuKSmoBXb1t1KdfG2cLe7FyBEAVakiZZmxxF0n/246PEDD3SduOp0RM+KcvQGFo38ts7XHLcoCWFUGFCT1QtRv6NCbDEAUY3kNZTvQB5GSU8WZN5F/khPDScnmR2DSvpT2VwCfYUIf2Ij5cwbcbftQ/mGJ9D79rI+73Faf7SetWvy6Ne7e6MxO/C07jzw6GLuvD4TT2Uxv794Ax1H5yG2REQCtpVpTxlo0WbonYg3BM+yHXUNaFJITuwBfF5/O2t1S5QnHzNzcCjNY2Fm/UbhbamXo8PUsGIqjdmMX1mTuKsALFNYpBcTV57I/BF1mNOm70Hk5wjqbRmG3o2b7SzOrP8s75y348g5x/1fDi4tyMKu0dQnEBI69Seh5fGUvfsQ1bu+oej3TZx9Zl9uyZ7N7ClZjcbwHVnDeG/DXby85EEq93zPjlfupO2lj1kcFPtZ1/JPG9K13uDKyTH4zbMUiJRy7mvikm6p9wOINLYFbUBPrvO1lB6DmYyolufb3mLx8E8a/KVqTmZ8/hP8VtCb8fkVaJaTrG/mqZFljM9fBpwB+nYWjgwEBk9YeQpa5yHsZEHmgCNHLRy2oD3efBoBtdCLLYsaZWvaEvsls0ntPRbEQO3by8PZ19Gj3zB2F5Y0GtMvLprBsX4Hx+s4P1scoQMI5rvua+lWbwa39pgORJpmUYaS+tlZ4BugPb8BH+U1TH46/pC3QpGnQNKBjZgTLsdTaTzhPfopZu7M20I6hpuBLmj5hMOUotlcHawgMhevJy10MeJI7T2O9CGPYEs1J+J+++EaOnU7mZWvftR4Do5XnqVpq2NNB8e7syjf+mGNHsD9/QXfFwAd6+fAyB+CcHcUheD6Ok23D2uEcdfQEPk5LKYs1Y4LDj249Cu039SZhZmngb7e+7CuYeJzrSBhAVACcpY/dGvycxleu1PhcT91ZIFLaE7kBkckaQaQ2PYUWo1cSorX2VFe8Csjhwzg4mvuxO1RDc54q4xmrFm9BltiKlp72L7uNqqLtxOV7/1Iq+BvCUDdXcQTVnVAWBz5gfEUi0YsOzD1KWLo0heg36zdwk8RGva4Q94KlcwhJ8dsJKUsxYxNtKHje7LwslJEnjVbq5j5STzxE4AkhLU8c+VhWxsgms0VvdJjDTPAbIlNaTF4BuUd+lP47kxUdQWvLptFh88+4rU1z3LCce0blPnzzuzBfbPmM/Wmq/BUFrNj7U0cPWopGPEhDNfQSVhP01ZNhaa6ji0flb8CkfQIB/cBu5mQf1cdLliKJ+45Fl9RZErElaeBDvUWVZK47zzmXO2qJfjPQqsPQm58KJOfy2Du6EMX+2czAr+dP7KC8fmlgB3tfZbifgJtuw4Yw+S8e3GT5VUNHz+cHRpGlL0pdQEVftXKpNRul9B21LMkZphz9XZ89wG9e53CQ0+vbvAbyL5xFOdl3mS2tD2b2fVmDrIfXvcLMnOjbqVkx73QHJHToxxNAHLQzKzD8iRG9STLO4k0trW61sACWDD8Q9NVHsKbO2HUIW2FWgUSBd2Qlwo094q0HQDMv/I74G2gKR55BugEehOLMt8+8sClqIrg0anR3RN6OMHRiaOvXEbaSVcBQnW5k7uvG8GAy2+gdG/DTvh99bnZtDvedBiVbF5H8aY1+3VP1eJQRZ2YULrhp2eLmGNtmXkJaD0ywo8uqIcOFiFaQo09pK1QcQOT15odepX4CrRVoeI3WV7MP73v5zJv0338cA+pimZzlda9XeqgP9/lE9M7Y0u2+895/8U5dOvTsPlK4uNsvPd6Pklp5oTOos+ficC0ddn/fWlN6WHzlprJZUCouvkrHb59p+5v3L0ECEncKX2ZtLLHoXNocCruyj8Yn78DjXd2tjzpV4lNJfkl4FfvJxfV5c9xmFMN4KplY4yyVsrNttUT2bV+Op4KMzekEZdEz/4jeWjmAw16E26PYtMPv9G8hTmspCqLqTP/Yd/QdQNXhbs0osOg/lQF+gsv0psRPKtYgZ7pdwLUheaP3gXMC/stLU0DV0/eBmwPOacY8WxpYH1wPfARIv2Ad7099DfA/cQVBntc80d6EP2dt33OOxKKakQ2PjIXHCew2Zoj0GbNtlSLdcUv77HrFXN8sulRXbl81Hhy75xIhzbpDaMKvvslz656lY8+fI/fvvs37opAJ9e0+1AyzrvPTECjPP61J+izO+x48Fo9xMqJdxOjw4Mm57XHLWYdbOXuwuKrthzuLEf2Ftrdv+CKq0YT7/OiaTFLp9Z27S7d6cfv2hdf4OxTGzYs6sorr6Tkj+/D+oomnfqT3v/2oAoo1lJD+Nf7k776+1iLPozIbVwP2gbkHwnAiq4Wzs2qBv1ruK1Sw6KD14mtT8Ln3z73rF4MHn0He1wNl2/jmSVLMOIC8Z4tB9xJp4lvcNTQx5HE1ACw6nIPwUsMXIcV6XOBPRjGw0cKx9E9XN2H9hNDetYY9VBDxHlcagsMWyIV2z9Fq2p+2bSBx+csokg5GNTvZA60zkO3zm0pMVrx0dtrvZpCFc1OzDTjc4MKMgQqngSvdUTp5l27SUy+na9XV8Ua9WFCX+TP54v8WXyet+3IB9fxQzNEjCGB+VHWdTCY/MFRIXO/ktv0IrXzQKpdW3CX7sRTVcZH61/in4tfoE3H7pzUveMBMX/BgN68/snvbPvxC9ylO1D79pLc/gwLiHQUgJngIxrwUBtZMe6ghNWkpeWkJSZekJyUNCi5qurNKrPgzOFFzZvnHJOUNNCelDTQXlU1sBje0TG019fmMo+s18rbk0vNa0GDeBuyd7q8RqNFEZ/RlTbD51Px6wfseW8m1cXbcf72FWOGncM/+o/g+YWPcHyXtvW+gbdXz6FDz03s/mkjxV8+S3xGF5ocd3GE2l1WtVWFVaa0qpFa6/X15adp0wfS4+Pdw9HSB3Pqe4nAV3Fuz/O7ynJ2h+nlYvsdcaea330wo7SUwsOuBzZsP/mcXxkZCc0KCg6jYYojzuYCeH7yD6B/ttpREVUoSxE6rLWyQop/pxzTnw7XvECLfrdiJDQBNJvez+eE47syZMzdFJdV1OsGkhITeOe11SQ0NYOGC9+ZSdXu7wK8eXlB6/2pgv5tlLxeH14y0nIvjY/z/IiWp4FJQCbCBC08Xh1v+9Vun3ZljY3Yts8Ta5JHKuXZHI7cvzkcudPatMlJqRlcgNZ6mbUB4i04RwRgBTVma7FvX+52pcAWT1qfcXQcu5bmx18KCKq6nHVLH+Kodl24c8a8et1W985tmbt4uVmswV1FwWv34KlwRSlCbq1IqYIlmrm9lRO3fVBXHuz2GT21kAfYo5ySIsiSjOYzekW7Rnw87lgjPSKdLeKwfz8HzcNosivLbZP2Cy5saqlGax2hRCohVRw1PjDpEKllqeqozMWWkkGrwQ/QYfQKklubswgqi3cwa8pk2nQ7i7XrP63z7Y0ddi5/+R/TXnGX7sT5Zg5aecJ4DGwHVMRgSczS+gzOiqj7NfhSA7hE67FK616iZZzAHh9+lHj+Hu0aiYnNYpLrCKR0e+4DXk0FQGOozbCfcFwARix4yzDk3OCSPTZvEs7Q4nNGyLFomXAt6aQRyn58g93v/QN3qXeGuBic2H8Y+c88QdeOdUvffsLZI9j03ioAmvS6hpRe16BUoMKJf5BYK7R/21/1xKMN93E8n1WnaQytWs1qUr2vsgBfTgjRWU7n1Lm+4w7H9OFo7ZuDX+Z0eeyQ4wZw2HNLgVQAp6tlQkZGUZLHU3UZSGuQbSLu953OnKgeModj+pkofT7gC37dqtAvFxVNjZpvvkWLnFRVHXeFNlQfMJqJplyL+srtVitLSnLCSq067LnK11YMW0KzgoK7Sq2/L1pfimnJupOTPQ/s2JFTnpExo7XHo8YAuFzNH4WbqtLTp/VVir5gpBpa/5SY4nltx46ccq9jp6NhGIO1FruIbImLk3d27753V2QHS25nm02fDXRAkSoYW5Woz1yu7A2h8YYOR+4E0RwbbAzpVYWFUz+x23PaixiDQNqLJsm3H6BNm5yUigpjHPCVyzX1wxqe/+1of54UD0KW05m9oHbgGj53kBi2NwLgCpRLDYDJWnzOmwU3Yu726OnPVHUlRZ8txvnpArTb9IDbkppx2V9uZsnj99IkuXb5YopLy2nfvQ8l278DhGbnZRPX4XQLwALlg4JLCXlQSi1j5cQ6JwV1OKafjta+maEqvtrTOth58XS8w7673OdAsnk8x+4pyfkpFFxKy9mG6OcAv4dHzNCkUYVFU14M9TIaYlsOXBhFU1noLHJn+UDs72XTcwdpxXIgI8K3SkUzrrAoe3VtwJWRMaO1cqsvEFqZvMq9ha4pD5i/M62vVrLR7MrVxWD0F7gn5Pd+FcN2sVLuXoLMg6DZGHsRhjmd2f8X2JVjONJs//CWqI2gdcnrKU1Srti27dYKC++vEzIrXMMTYLwuqOeBJoGv60lO59T55jud9ghabgHciBridN4XZoc70nKvRViAOa+4Cs1o67Pbf674VZPfRLMh1LZSYaqWV/UL/WxZq0DBb2/NrEDIEbYE7Kdl0WHMSzTtZk7h91SWsHp+Lq3ad+ehf62sndu4aQr/t+4FbMlmPvvS92bhdm218KSj2WIaDw/VS+PWqovl485wr2BWtcBskLkgc/eJLaL6Z4h+1wosb0NI1OinIScuWA01FluApYBvQG/GF4Moeny63XZXaI+vFWtCgGX1JDXVwvKMjAe67v+uc+K0Ry33AQstbxS63BGrdArGKxGABdBJK893gjwbAiyAJmjmeTMLeTsxYyLCbd5260H4DLBModEX7N1bNmW/KjzcKKiXg4AVTmV+v7k28uz2GScGdVJpuZcjzPN2OqUodUlop1SryhNaVLaOBCZvw7Q6LkKLzwWA5fGCKhC/p62xfN5to0kLWgyeRuthT5OQYUrzvQW/cvf1mbTpdhavvbf/6jqnndSVWU8uBjHQ1RXsXT8Dta8sIp+We1rCmomb6qd1W4JeoSjSGYWu7LudrilZTteUrOLi7F+jPOnNiB5laM4xgehvDa1aNAukHUhLm3aKIN6pF5SLIWc4Xdk9na6p3UWpwXgrS2rNjZDnH8uMM7jNJyUFftYYJzld2SliSDvAV/86Qbnd+80wZLfbpmmzjjbAH3EJcg3UZKvqdQgXmVKMYIeRZqNGLhWD89F6leVI+/T0GW0sDfEv/i1Dn+V0ZvdxurKPR+Q2C3CGBbkNPPyPoXQfQ+k+BKLqAbYjegKiz/Qdr64OpKdzOtX9gK8AQjNBvepw5LQzvcL3n6OF5ZjjxE5EX1BYfN9btXfFWyl/0nqt1fJQ93qYRzCoimNAMvkllaWaY1iwbAjIEtv0os2oZWQMyvFPWdn5/QYuPudUTr/kWrbvctbI8t+uvZxLrjHTlnuKt1Hx4WNhgApUotQlKHVPfQ1aEZIsDaXe0dpKc53TOTWvoCj7HafLfT2ww39MbO0tUusCS2N6prBwykY/iM2X/JYPlBkZP3UOsCYXWMTtNJfr3v8AFBZO2Y4wNdCGJapH0+Op6uhwTB8lcJefNcXV0ewjn4qXlKxGOp3Zr7lc970qBpODO29jgss1ZW1hYfabzqK0qzHrLHvZpEOAf/UgIiMNzeWFhVM/DlzBnWd5G0dbr72nJPvHguKpnxUUT/0MqLQ8izuczqkLnc6pH/mOl5bmWGZj57idrinXo5lqKhC00dr2ot2ee7ES40Wvff27GPRzOqdGTBYTV/s3r27TIhdrpLmZn1288a+Cd1gWAzHXCjNPu3jztwuBvILWfO3eXIH+KA8dkrVJQ0rXC0nqcCYlny+l9KsVaFXNx68spkOnNWSOv5VnHvk7CfGRb+OlRbM45usv2frFW7h/+xj59iVs3S6OIL0897A6q97FwrWmMjCBWafW9zpxcbYfLC9XQe5WoA2Atqn4wE9wrO8ZafQ5jrTcN0Iu5a+K4Xaro4AfTLVSdwp06cFZk5zOlm83b76zsznexr7oKpX8xx/4bO6YUVicvb9B920+x4UJ5ua/OOzFFnW1+ieXH043VQm5W7R3SEOpwH27XPe9ClqaN5/eMS1t+gCbTSd43QipAeWRWmWzMgxq4bQS7Swi1+GYvhmtl4hZCned99gvHuU+v9iV80vU91nrN786a6ceMX+SQuUZCFoUSlsA5QdYYG0aAxZQoUMKIRhmJjRvwk7xZbwNm9acQtPTskg+7kKKNzxB5W//xlNRzIon72PdmuX8438f5rqrLorwAIWN/7eSjt1PpqJgK9VfPAvN20KrHlbp9So9d/yLlRwASVGAaWkexemxCKXbeY2rbKdzyr8jvPBQtUpFeecWAEs3hG41NCLTK+kgxVujwrvf4wq1C4uL+aXO/YrW+bXpmkMGHYI+b9ni0MGSDBVpGp7pOJq+GDgOtDnkWju3XGQ9oZbkdE7Jt9undxL0QwF1U1/oLMmp8XnVrdrfyon5WnueDlUHgx0XnoBXzl/QO+DECPXYqRDHRtRFezCatSXtwgexXzKLOLupLZTu2Mz1oy+mXc8BbPgiPGtZy4w0XnhhNZKQAlpRveGfqLJdPr62Ee8ZU69Jh0HDgfxo+dgmI2NG69DRe7S+EmEQwiDDc4CDxVrKLJJjotOVLVEX55QNZgOhHEu3pZQtZLD78cSM5tN6ZzSf1ttun3ZCDd6ARV5HglcjlrlWu66xyG6f2Ryt15nAolrQNxpK+hpK91FaD2zM33Y4cgcL+t4g9djGKrs9p33DgQsgNf4WrdVHoaCK5Bn0gSocRAGbS0eyuSItluPxrU/GfsUcmpx+HZJgOny2f/M+/U49iX6XT2R3QbBPYfBZvbj3wSe8ju0y1IdPoN2VFRoZyfKsA856lGp3b7J4l0R7PMODPUs/XOobAxOoSmqackDliUT0TxaV9KRI40A+oIAv532OGyRg0Ht03yAem7v6KUM+VYZ8KsiS6JIw4WYRuQzw6XWnOxzf39LY4BJxDwIcVelP1wAABhxJREFUXl343ULX1H8WFE/5tKB46meGQUHjgTr3ejTrMFPtfY9mPGaahBME24dpadNOajhwLb62UovnIq3Vf5S2DM6GAcsCpJDBWh1p5m9UyeWO7PhASDz+UpqPWEBi96GmZ9C9jw9fXEDbTl24IfthlEXy5946njMvG2e+G9dW9Bv3byR/QoNkLd2yJadSwxqLsTzTbp9+p8ORO9iRlnuzFr3Aoh+9ah2HqVdDU8brFofGWKvrvGXLGa1sBh94gfJBx45OsZz7WsBBYmQ7HNN6eAeVj9KGMc3yCxtr+v3CwinbNfpuixMnt3bu+wO5Z2UZj6JbixY5R/nG+0TLzIb/RS0OR26OwFNe86nQ5mGosyh7ERqfN7WdIfKB3T59aMOACyA/q1jbjCFaqy3+cSurZ9APqlDvoIo+tb4GyeWJBEKf5EtIIenUiTS5ZBa2lqYd7y4rZM7020g7ujsLV/rbE++umkeLrt56YqV/nA1MbqhXoZQnB/zR4k0E/RCa1xEexWucC1RprXMO9LcKiu/9HPQ6n5tYeTyfO+y5r9vtuS+6q9X3wFFe58PCLVty/B4yt9IP+ySsoLugZZPDnlvqcdt2Amd6T6vWqH/ujweXS821uNSTlcczH3Iarai4mLk1fNTO47ZtddhzfzfEtkfDkEjfSU+f3tZhz9W+BfBPh9dKNlqOecIl1oy70Nzn/ViJ6KF7SrJ/BHAWZS/SaF8imFRBr3Y4Hji+YcAFsGL879rjOVNr9ZWyuuGDQBXF7R5F3dufzRW2bRk3E3tHkgbnkNjvZiQl3WuPfc+EkRdz3FlD+fqHrcTZbHz57rryuLg4XzjR40CDVO8rLs75RSMXA1uj2Cq7tXB5UdHUBilf6vaoMYi85R9whcECl+LL+SesTkx23xHMY/bPYnCFJdYR37iXz2Wu0WNcrqlf12IQWYnBZMGfhq9/eprtr40FroLiqZ9ptDVKJQGz0EUcoqdreKGBJVc7v7IhMibU3e5yZU8BVvgcg+Kpbl1/b2E0D+Lop87R1QkvGJoB1jKpBgb+aHMRtASXTEVbJlt6XfpiVWAsOkfA8xsIuNUQMs3F9P5J+9NJaHMy7m/X4vnuZfDs44cNL3NSzzd15lV/+XzpvCd7vvPOO+X9+vXzldT5B4QU7q4nuVxTPujYMadbaVHcBdrQvUVLukIViRhfxscnvrJr1x1hY2AaFglmfkK3u7oi+Ji8JPh67Pjfrce8MYCDMtLuP8cjxvlAO4FyDb8ahn4neBzIqtJlv9miRc4xqtoYpkT6GGbKtmIFX1dX21aWlf19T4SvzfVVt0hNraguKPBf67v0tOlZiCn1NLqT6fLPcXs8ao8hcXO9YidkmMOuYM9ciz/OEyKl1mjkM+/wxM7A8+02PD3th9EIZypUawNjp0I953JOfT+j+bTeHkP+LSKewJice6+fh/0NpoR2Xm7bffHxngKt5TOXc8raiG561+Pj7Pbiz0V0caRBZGkQkA/MiSOj7RQRI9sQw4hc8Du4ZCqWAgm+onMSxpYO/q/x58TQvu2o4UwKvbcA9VUe+vdAO0tISNjy5JNP7p49e7bavHnz6UAhkePsYhSjA1NlG/RqmfMvEZgnGK2DI9+NoJKpoQDzsyKEAExb+hXtl10EAUvXEC+oPFqrJ3j5by9RWTYLs4ZvKK0Hzos1hRgd3uACs3J9xb5sEblNROKC6xMH1x721xQJ1EwNY0hbt3QgcbYOmx2tAoAz4x4/10rdwKqsjy325bXADPAGm8IuYBCwKdYUYnT4g8tHw+ediMh9InK5iBgmoAw/mMRSrE4iSi4LuGolubQ34Yz+Xmv9AD23L4syONwEuAgzTGYdUBJrBjE6ssDlB9ncHojcIWJkCpKCJUNUJMkV7s7Yj+QKpCD4t9bqMXruyDvQiIsYxejIAJePLl3QlHg9DGG0iPQXSA6TXAEBFiK1okgu9LdasxqbWmom1IlRjP6M4LLSuEVJlKgzEM9ADKOHQDeQLgRyUEQg/TuaHzR6MyIb8HjePpBI9hjF6L8TXJEoM89GfEEzquPTQKWCkYChijCMMspUKWuzymOvK0ZHEv0/MoxQeluHjNMAAAAASUVORK5CYII="
+			alt="" />
+		ZAP Report
+	</h1>
+	<p />
+
+
+	<h2>
+
+		Site: http://api:8000
+
+	</h2>
+
+	<h3>
+		Generated on Sun, 14 Dec 2025 09:01:57
+	</h3>
+
+	<h3>
+		ZAP Version: 2.16.1
+	</h3>
+
+	<h4>
+		ZAP by <a href="https://checkmarx.com/">Checkmarx</a>
+	</h4>
+
+
+		<h3 class="left-header">Summary of Alerts</h3>
+		<table class="summary">
+			<tr>
+				<th width="45%"
+					height="24">Risk Level</th>
+				<th width="55%"
+					align="center">Number of Alerts</th>
+			</tr>
+			<tr>
+				<td class="risk-3">
+					<div>High</div>
+				</td>
+				<td align="center">
+					<div>0</div>
+				</td>
+			</tr>
+			<tr>
+				<td class="risk-2">
+					<div>Medium</div>
+				</td>
+				<td align="center">
+					<div>2</div>
+				</td>
+			</tr>
+			<tr>
+				<td class="risk-1">
+					<div>Low</div>
+				</td>
+				<td align="center">
+					<div>2</div>
+				</td>
+			</tr>
+			<tr>
+				<td class="risk-0">
+					<div>Informational</div>
+				</td>
+				<td align="center">
+					<div>1</div>
+				</td>
+			</tr>
+			<tr>
+				<td class="risk--1">
+					<div>				False Positives:</div>
+				</td>
+				<td align="center">
+					<div>0</div>
+				</td>
+			</tr>
+		</table>
+		<div class="spacer-lg"></div>
+
+
+
+
+			<h3>Summary of Sequences</h3>
+			<p class="smallnote">For each step: result (Pass/Fail) - risk (of highest alert(s) for the step, if any).</p>
+
+
+
+
+
+
+		<h3>Alerts</h3>
+		<table class="alerts">
+			<tr>
+				<th width="60%" height="24">Name</th>
+				<th width="20%"
+					align="center">Risk Level</th>
+				<th width="20%"
+					align="center">Number of Instances</th>
+			</tr>
+			<tr>
+				<td><a href="#10038">Content Security Policy (CSP) Header Not Set</a></td>
+				<td align="center" class="risk-2">Medium</td>
+
+
+				<td align="center">1</td>
+
+			</tr>
+			<tr>
+				<td><a href="#10020">Missing Anti-clickjacking Header</a></td>
+				<td align="center" class="risk-2">Medium</td>
+
+
+				<td align="center">1</td>
+
+			</tr>
+			<tr>
+				<td><a href="#10017">Cross-Domain JavaScript Source File Inclusion</a></td>
+				<td align="center" class="risk-1">Low</td>
+
+
+				<td align="center">1</td>
+
+			</tr>
+			<tr>
+				<td><a href="#10021">X-Content-Type-Options Header Missing</a></td>
+				<td align="center" class="risk-1">Low</td>
+
+
+				<td align="center">1</td>
+
+			</tr>
+			<tr>
+				<td><a href="#10109">Modern Web Application</a></td>
+				<td align="center" class="risk-0">Informational</td>
+
+
+				<td align="center">1</td>
+
+			</tr>
+		</table>
+		<div class="spacer-lg"></div>
+
+
+
+		<h3>Alert Detail</h3>
+
+			<table class="results">
+				<tr height="24">
+					<th width="20%" class="risk-2"><a
+						id="10038"></a>
+						<div>Medium</div></th>
+					<th class="risk-2">Content Security Policy (CSP) Header Not Set</th>
+				</tr>
+				<tr>
+					<td width="20%">Description</td>
+					<td width="80%">
+							<div>Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.</div>
+
+						</td>
+				</tr>
+				<TR vAlign="top">
+					<TD colspan="2"></TD>
+				</TR>
+
+					<tr>
+						<td width="20%"
+							class="indent1">URL</td>
+						<td width="80%"><a href="http://api:8000/docs">http://api:8000/docs</a></td>
+					</tr>
+
+					<tr>
+						<td width="20%"
+							class="indent2">Method</td>
+						<td width="80%">GET</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Parameter</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Attack</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Evidence</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Other Info</td>
+						<td width="80%"></td>
+					</tr>
+
+				<tr>
+					<td width="20%">Instances</td>
+
+
+					<td width="80%">1</td>
+
+				</tr>
+				<tr>
+					<td width="20%">Solution</td>
+					<td width="80%">
+							<div>Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header.</div>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">Reference</td>
+					<td width="80%">
+							<a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP">https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP</a>
+							<br />
+
+							<a href="https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html">https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html</a>
+							<br />
+
+							<a href="https://www.w3.org/TR/CSP/">https://www.w3.org/TR/CSP/</a>
+							<br />
+
+							<a href="https://w3c.github.io/webappsec-csp/">https://w3c.github.io/webappsec-csp/</a>
+							<br />
+
+							<a href="https://web.dev/articles/csp">https://web.dev/articles/csp</a>
+							<br />
+
+							<a href="https://caniuse.com/#feat=contentsecuritypolicy">https://caniuse.com/#feat=contentsecuritypolicy</a>
+							<br />
+
+							<a href="https://content-security-policy.com/">https://content-security-policy.com/</a>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">CWE Id</td>
+					<td width="80%"><a
+						href="https://cwe.mitre.org/data/definitions/693.html">693</a></td>
+				</tr>
+				<tr>
+					<td width="20%">WASC Id</td>
+					<td width="80%">15</td>
+				</tr>
+				<tr>
+					<td width="20%">Plugin Id</td>
+					<td width="80%"><a
+						href="https://www.zaproxy.org/docs/alerts/10038/">10038</a></td>
+				</tr>
+			</table>
+			<div class="spacer"></div>
+
+			<table class="results">
+				<tr height="24">
+					<th width="20%" class="risk-2"><a
+						id="10020"></a>
+						<div>Medium</div></th>
+					<th class="risk-2">Missing Anti-clickjacking Header</th>
+				</tr>
+				<tr>
+					<td width="20%">Description</td>
+					<td width="80%">
+							<div>The response does not protect against &#39;ClickJacking&#39; attacks. It should include either Content-Security-Policy with &#39;frame-ancestors&#39; directive or X-Frame-Options.</div>
+
+						</td>
+				</tr>
+				<TR vAlign="top">
+					<TD colspan="2"></TD>
+				</TR>
+
+					<tr>
+						<td width="20%"
+							class="indent1">URL</td>
+						<td width="80%"><a href="http://api:8000/docs">http://api:8000/docs</a></td>
+					</tr>
+
+					<tr>
+						<td width="20%"
+							class="indent2">Method</td>
+						<td width="80%">GET</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Parameter</td>
+						<td width="80%">x-frame-options</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Attack</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Evidence</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Other Info</td>
+						<td width="80%"></td>
+					</tr>
+
+				<tr>
+					<td width="20%">Instances</td>
+
+
+					<td width="80%">1</td>
+
+				</tr>
+				<tr>
+					<td width="20%">Solution</td>
+					<td width="80%">
+							<div>Modern Web browsers support the Content-Security-Policy and X-Frame-Options HTTP headers. Ensure one of them is set on all web pages returned by your site/app.</div>
+							<br />
+
+							<div>If you expect the page to be framed only by pages on your server (e.g. it&#39;s part of a FRAMESET) then you&#39;ll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. Alternatively consider implementing Content Security Policy&#39;s &quot;frame-ancestors&quot; directive.</div>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">Reference</td>
+					<td width="80%">
+							<a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options">https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options</a>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">CWE Id</td>
+					<td width="80%"><a
+						href="https://cwe.mitre.org/data/definitions/1021.html">1021</a></td>
+				</tr>
+				<tr>
+					<td width="20%">WASC Id</td>
+					<td width="80%">15</td>
+				</tr>
+				<tr>
+					<td width="20%">Plugin Id</td>
+					<td width="80%"><a
+						href="https://www.zaproxy.org/docs/alerts/10020/">10020</a></td>
+				</tr>
+			</table>
+			<div class="spacer"></div>
+
+			<table class="results">
+				<tr height="24">
+					<th width="20%" class="risk-1"><a
+						id="10017"></a>
+						<div>Low</div></th>
+					<th class="risk-1">Cross-Domain JavaScript Source File Inclusion</th>
+				</tr>
+				<tr>
+					<td width="20%">Description</td>
+					<td width="80%">
+							<div>The page includes one or more script files from a third-party domain.</div>
+
+						</td>
+				</tr>
+				<TR vAlign="top">
+					<TD colspan="2"></TD>
+				</TR>
+
+					<tr>
+						<td width="20%"
+							class="indent1">URL</td>
+						<td width="80%"><a href="http://api:8000/docs">http://api:8000/docs</a></td>
+					</tr>
+
+					<tr>
+						<td width="20%"
+							class="indent2">Method</td>
+						<td width="80%">GET</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Parameter</td>
+						<td width="80%">https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Attack</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Evidence</td>
+						<td width="80%">&lt;script src=&quot;https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js&quot;&gt;&lt;/script&gt;</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Other Info</td>
+						<td width="80%"></td>
+					</tr>
+
+				<tr>
+					<td width="20%">Instances</td>
+
+
+					<td width="80%">1</td>
+
+				</tr>
+				<tr>
+					<td width="20%">Solution</td>
+					<td width="80%">
+							<div>Ensure JavaScript source files are loaded from only trusted sources, and the sources can&#39;t be controlled by end users of the application.</div>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">Reference</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">CWE Id</td>
+					<td width="80%"><a
+						href="https://cwe.mitre.org/data/definitions/829.html">829</a></td>
+				</tr>
+				<tr>
+					<td width="20%">WASC Id</td>
+					<td width="80%">15</td>
+				</tr>
+				<tr>
+					<td width="20%">Plugin Id</td>
+					<td width="80%"><a
+						href="https://www.zaproxy.org/docs/alerts/10017/">10017</a></td>
+				</tr>
+			</table>
+			<div class="spacer"></div>
+
+			<table class="results">
+				<tr height="24">
+					<th width="20%" class="risk-1"><a
+						id="10021"></a>
+						<div>Low</div></th>
+					<th class="risk-1">X-Content-Type-Options Header Missing</th>
+				</tr>
+				<tr>
+					<td width="20%">Description</td>
+					<td width="80%">
+							<div>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &#39;nosniff&#39;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</div>
+
+						</td>
+				</tr>
+				<TR vAlign="top">
+					<TD colspan="2"></TD>
+				</TR>
+
+					<tr>
+						<td width="20%"
+							class="indent1">URL</td>
+						<td width="80%"><a href="http://api:8000/docs">http://api:8000/docs</a></td>
+					</tr>
+
+					<tr>
+						<td width="20%"
+							class="indent2">Method</td>
+						<td width="80%">GET</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Parameter</td>
+						<td width="80%">x-content-type-options</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Attack</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Evidence</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Other Info</td>
+						<td width="80%">This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.
+At &quot;High&quot; threshold this scan rule will not alert on client or server error responses.</td>
+					</tr>
+
+				<tr>
+					<td width="20%">Instances</td>
+
+
+					<td width="80%">1</td>
+
+				</tr>
+				<tr>
+					<td width="20%">Solution</td>
+					<td width="80%">
+							<div>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &#39;nosniff&#39; for all web pages.</div>
+							<br />
+
+							<div>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</div>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">Reference</td>
+					<td width="80%">
+							<a href="https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)">https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)</a>
+							<br />
+
+							<a href="https://owasp.org/www-community/Security_Headers">https://owasp.org/www-community/Security_Headers</a>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">CWE Id</td>
+					<td width="80%"><a
+						href="https://cwe.mitre.org/data/definitions/693.html">693</a></td>
+				</tr>
+				<tr>
+					<td width="20%">WASC Id</td>
+					<td width="80%">15</td>
+				</tr>
+				<tr>
+					<td width="20%">Plugin Id</td>
+					<td width="80%"><a
+						href="https://www.zaproxy.org/docs/alerts/10021/">10021</a></td>
+				</tr>
+			</table>
+			<div class="spacer"></div>
+
+			<table class="results">
+				<tr height="24">
+					<th width="20%" class="risk-0"><a
+						id="10109"></a>
+						<div>Informational</div></th>
+					<th class="risk-0">Modern Web Application</th>
+				</tr>
+				<tr>
+					<td width="20%">Description</td>
+					<td width="80%">
+							<div>The application appears to be a modern web application. If you need to explore it automatically then the Ajax Spider may well be more effective than the standard one.</div>
+
+						</td>
+				</tr>
+				<TR vAlign="top">
+					<TD colspan="2"></TD>
+				</TR>
+
+					<tr>
+						<td width="20%"
+							class="indent1">URL</td>
+						<td width="80%"><a href="http://api:8000/docs">http://api:8000/docs</a></td>
+					</tr>
+
+					<tr>
+						<td width="20%"
+							class="indent2">Method</td>
+						<td width="80%">GET</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Parameter</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Attack</td>
+						<td width="80%"></td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Evidence</td>
+						<td width="80%">&lt;script src=&quot;https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js&quot;&gt;&lt;/script&gt;</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">Other Info</td>
+						<td width="80%">No links have been found while there are scripts, which is an indication that this is a modern web application.</td>
+					</tr>
+
+				<tr>
+					<td width="20%">Instances</td>
+
+
+					<td width="80%">1</td>
+
+				</tr>
+				<tr>
+					<td width="20%">Solution</td>
+					<td width="80%">
+							<div>This is an informational alert and so no changes are required.</div>
+
+						</td>
+				</tr>
+				<tr>
+					<td width="20%">Reference</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">CWE Id</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">WASC Id</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">Plugin Id</td>
+					<td width="80%"><a
+						href="https://www.zaproxy.org/docs/alerts/10109/">10109</a></td>
+				</tr>
+			</table>
+			<div class="spacer"></div>
+
+
+
+
+
+			<h3>Sequence Details</h3>
+			<sup>With the associated active scan results.</sup>
+
+
+
+			<div class="spacer-lg"></div>
+
+
+
+
+</body>
+</html>

--- a/EVIDENCE/P11/zap_baseline.json
+++ b/EVIDENCE/P11/zap_baseline.json
@@ -1,0 +1,169 @@
+{
+	"@programName": "ZAP",
+	"@version": "2.16.1",
+	"@generated": "Sun, 14 Dec 2025 09:02:13",
+	"created": "2025-12-14T09:02:13.742604201Z",
+	"site":[
+		{
+			"@name": "http://api:8000",
+			"@host": "api",
+			"@port": "8000",
+			"@ssl": "false",
+			"alerts": [
+				{
+					"pluginid": "10038",
+					"alertRef": "10038-1",
+					"alert": "Content Security Policy (CSP) Header Not Set",
+					"name": "Content Security Policy (CSP) Header Not Set",
+					"riskcode": "2",
+					"confidence": "3",
+					"riskdesc": "Medium (High)",
+					"desc": "<p>Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page \u2014 covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.</p>",
+					"instances":[
+						{
+							"id": "3",
+							"uri": "http://api:8000/docs",
+							"nodeName": null,
+							"method": "GET",
+							"param": "",
+							"attack": "",
+							"evidence": "",
+							"otherinfo": ""
+						}
+					],
+					"count": "1",
+					"systemic": false,
+					"solution": "<p>Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header.</p>",
+					"otherinfo": "",
+					"reference": "<p>https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP</p><p>https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html</p><p>https://www.w3.org/TR/CSP/</p><p>https://w3c.github.io/webappsec-csp/</p><p>https://web.dev/articles/csp</p><p>https://caniuse.com/#feat=contentsecuritypolicy</p><p>https://content-security-policy.com/</p>",
+					"cweid": "693",
+					"wascid": "15",
+					"sourceid": "6"
+				},
+				{
+					"pluginid": "10020",
+					"alertRef": "10020-1",
+					"alert": "Missing Anti-clickjacking Header",
+					"name": "Missing Anti-clickjacking Header",
+					"riskcode": "2",
+					"confidence": "2",
+					"riskdesc": "Medium (Medium)",
+					"desc": "<p>The response does not protect against 'ClickJacking' attacks. It should include either Content-Security-Policy with 'frame-ancestors' directive or X-Frame-Options.</p>",
+					"instances":[
+						{
+							"id": "1",
+							"uri": "http://api:8000/docs",
+							"nodeName": null,
+							"method": "GET",
+							"param": "x-frame-options",
+							"attack": "",
+							"evidence": "",
+							"otherinfo": ""
+						}
+					],
+					"count": "1",
+					"systemic": false,
+					"solution": "<p>Modern Web browsers support the Content-Security-Policy and X-Frame-Options HTTP headers. Ensure one of them is set on all web pages returned by your site/app.</p><p>If you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. Alternatively consider implementing Content Security Policy's \"frame-ancestors\" directive.</p>",
+					"otherinfo": "",
+					"reference": "<p>https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options</p>",
+					"cweid": "1021",
+					"wascid": "15",
+					"sourceid": "1"
+				},
+				{
+					"pluginid": "10017",
+					"alertRef": "10017",
+					"alert": "Cross-Domain JavaScript Source File Inclusion",
+					"name": "Cross-Domain JavaScript Source File Inclusion",
+					"riskcode": "1",
+					"confidence": "2",
+					"riskdesc": "Low (Medium)",
+					"desc": "<p>The page includes one or more script files from a third-party domain.</p>",
+					"instances":[
+						{
+							"id": "4",
+							"uri": "http://api:8000/docs",
+							"nodeName": null,
+							"method": "GET",
+							"param": "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+							"attack": "",
+							"evidence": "<script src=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js\"></script>",
+							"otherinfo": ""
+						}
+					],
+					"count": "1",
+					"systemic": false,
+					"solution": "<p>Ensure JavaScript source files are loaded from only trusted sources, and the sources can't be controlled by end users of the application.</p>",
+					"otherinfo": "",
+					"reference": "",
+					"cweid": "829",
+					"wascid": "15",
+					"sourceid": "1"
+				},
+				{
+					"pluginid": "10021",
+					"alertRef": "10021",
+					"alert": "X-Content-Type-Options Header Missing",
+					"name": "X-Content-Type-Options Header Missing",
+					"riskcode": "1",
+					"confidence": "2",
+					"riskdesc": "Low (Medium)",
+					"desc": "<p>The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.</p>",
+					"instances":[
+						{
+							"id": "8",
+							"uri": "http://api:8000/docs",
+							"nodeName": null,
+							"method": "GET",
+							"param": "x-content-type-options",
+							"attack": "",
+							"evidence": "",
+							"otherinfo": "This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.\nAt \"High\" threshold this scan rule will not alert on client or server error responses."
+						}
+					],
+					"count": "1",
+					"systemic": false,
+					"solution": "<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.</p><p>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.</p>",
+					"otherinfo": "<p>This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.</p><p>At \"High\" threshold this scan rule will not alert on client or server error responses.</p>",
+					"reference": "<p>https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)</p><p>https://owasp.org/www-community/Security_Headers</p>",
+					"cweid": "693",
+					"wascid": "15",
+					"sourceid": "1"
+				},
+				{
+					"pluginid": "10109",
+					"alertRef": "10109",
+					"alert": "Modern Web Application",
+					"name": "Modern Web Application",
+					"riskcode": "0",
+					"confidence": "2",
+					"riskdesc": "Informational (Medium)",
+					"desc": "<p>The application appears to be a modern web application. If you need to explore it automatically then the Ajax Spider may well be more effective than the standard one.</p>",
+					"instances":[
+						{
+							"id": "6",
+							"uri": "http://api:8000/docs",
+							"nodeName": null,
+							"method": "GET",
+							"param": "",
+							"attack": "",
+							"evidence": "<script src=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js\"></script>",
+							"otherinfo": "No links have been found while there are scripts, which is an indication that this is a modern web application."
+						}
+					],
+					"count": "1",
+					"systemic": false,
+					"solution": "<p>This is an informational alert and so no changes are required.</p>",
+					"otherinfo": "<p>No links have been found while there are scripts, which is an indication that this is a modern web application.</p>",
+					"reference": "",
+					"cweid": "-1",
+					"wascid": "-1",
+					"sourceid": "1"
+				}
+			]
+		}
+	],
+	"sequences":[
+	]
+
+}

--- a/EVIDENCE/P11/zap_summary.md
+++ b/EVIDENCE/P11/zap_summary.md
@@ -1,0 +1,25 @@
+# ZAP summary
+
+**Target:** `target=http://api:8000/docs`
+
+**Total:** 5
+
+## Severity
+
+- High: 0
+- Medium: 2
+- Low: 2
+- Informational: 1
+- Unknown: 0
+
+## Examples
+
+- Medium: Content Security Policy (CSP) Header Not Set
+- Medium: Missing Anti-clickjacking Header
+- Low: Cross-Domain JavaScript Source File Inclusion
+- Low: X-Content-Type-Options Header Missing
+- Informational: Modern Web Application
+
+---
+Commit: `0ca59df24ea6321f98ffde90913b1f6d04da522e`
+Run: https://github.com/Mushkat/Mushkat-secdev-2025/actions/runs/20205602086

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.core.exceptions import (
     validation_exception_handler,
 )
 from app.middleware.rate_limit import RateLimitMiddleware
+from app.middleware.security_headers import SecurityHeadersMiddleware
 
 exception_handlers = {
     APIError: api_error_handler,
@@ -30,6 +31,7 @@ def on_startup() -> None:
 
 
 app.add_middleware(RateLimitMiddleware)
+app.add_middleware(SecurityHeadersMiddleware)
 
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 app.include_router(items.router, prefix="/api/v1", tags=["items"])

--- a/app/middleware/security_headers.py
+++ b/app/middleware/security_headers.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response: Response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        return response


### PR DESCRIPTION
## Контекст

Цель: встроить минимальное DAST-сканирование в CI для сервиса: поднять приложение на раннере, прогнать OWASP ZAP, сохранить отчёты в `EVIDENCE/P11/` и зафиксировать результат/решения по найденным предупреждениям.


## Что сделано
### C1 - Запуск сервиса в CI

- Добавлен workflow `.github/workflows/ci-p11-dast.yml`, который поднимает реальный сервис через `docker compose up -d --build`.
- Реализовано ожидание готовности по health-endpoint: `GET /health`.
- Сканирование выполняется только после успешного readiness.


### C2 - Запуск ZAP baseline

- ZAP-скан запускается для поднятого сервиса внутри docker-compose сети, таргет выбирается предсказуемо:

  - основной стартовый URL: `/docs` (если доступен), иначе `/`.
- Генерируются два отчёта: HTML и JSON.
- Запуск ZAP не ломает CI из-за findings (scan выполняется, отчёты сохраняются, job остаётся зелёным).


### C3 - Артефакты в EVIDENCE/P11

- Добавлена структура `EVIDENCE/P11/` и в неё помещаются:

  - `zap_baseline.html` - оформленный отчёт
  - `zap_baseline.json` - json отчёт
  - `zap_summary.md` - краткая сводка по severity (High/Medium/Low/Info)
  - `compose.log`, `ci_debug.md`, `target.txt` - для трассировки и воспроизводимости
- Те же файлы публикуются как артефакт `P11_EVIDENCE` в Actions.


### C4 - Интерпретация результатов

- В `EVIDENCE/P11/zap_summary.md` зафиксировано резюме: сколько алертов по уровням (High/Medium/Low/Info).
- Выбран и обработан набор алертов:

  1. Фикс: добавлен `SecurityHeadersMiddleware` в `app/main.py`, который проставляет защитные заголовки:

     - `X-Frame-Options: DENY` (anti-clickjacking)
     - `X-Content-Type-Options: nosniff`
       Это адресует findings вида *Missing Anti-clickjacking Header* и *X-Content-Type-Options Header Missing*.
  2. Осознанное принятие риска: остаются информационные предупреждения, связанные со Swagger UI (`/docs`), они трактуются как относящиеся к dev-интерфейсу; при необходимости отключать `/docs` в prod или переводить swagger assets на self-host.


### C5 - Интеграция в CI

- Workflow вынесен отдельным файлом и не конфликтует с другими.
- Есть:

  - триггеры: `workflow_dispatch` + `push` по релевантным путям
  - `concurrency`, чтобы не копились параллельные прогоны
  - минимальные permissions (`contents: read`, `packages: read` для pull ZAP из GHCR)
- Артефакты всегда загружаются через `if: always()`.

**Доказательства:**

- [Чек](https://github.com/Mushkat/Mushkat-secdev-2025/pull/11/checks)
- [P11_EVIDENCE.zip](https://github.com/user-attachments/files/24148997/P11_EVIDENCE.zip)
- [.github/workflows/ci-p11-dast.yml](https://github.com/Mushkat/Mushkat-secdev-2025/pull/11/files#diff-7eeac584a1d6f9d49df9e3b1a95325c6d63d37bf858f85bd35ae5f047c26e7b2)

## Как проверял(а)
- [x] `docker compose up -d --build` поднимает сервис в CI
- [x] `/health` отвечает `200 OK` до запуска ZAP
- [x] ZAP выполняет сканирование по URL из `target.txt`
- [x] Сгенерированы отчёты `zap_baseline.html` и `zap_baseline.json` и сохранены в `EVIDENCE/P11/`
- [x] Сгенерирован `zap_summary.md` с распределением по severity
- [x] Добавлен `SecurityHeadersMiddleware`
- [x] Артефакт `P11_EVIDENCE` в Actions соответствует `EVIDENCE/P11/` в репозитории
